### PR TITLE
Start conversation on new logging library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 
 node_modules
 package-lock.json
+
+.nyc_output
+coverage

--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+# RSC NodeJS JSON Logging Library
+Simple logging library to reduce initialization and options.
+But rather to just `console.log` in a standard JSON format
+
+## Usage
+```js
+const log = require('rsc-clean-log-json')
+
+log.info(`Event saved`) 
+// { "level": "info", "msg": "Event saved" }
+
+log.error(`Error saving`, new Error(`database-offline`)) 
+// { "level": "error", "msg": "Event saving", "errorMsg": "database-offline" }
+
+log.warn(`Not too serious`, { userId: 1, name: 'John Doe'} )
+// { "level": "error", "msg": "Not too serious", "userId": 1, "name": "John Doe" }
+```
+
+## Methods
+- `log.debug()`
+- `log.info()`
+- `log.wanr()`
+- `log.error()`
+- `log.alert()`

--- a/README.md
+++ b/README.md
@@ -7,18 +7,36 @@ But rather to just `console.log` in a standard JSON format
 const log = require('rsc-clean-log-json')
 
 log.info(`Event saved`) 
-// { "level": "info", "msg": "Event saved" }
+// { "level": "info", "message": "Event saved" }
 
 log.error(`Error saving`, new Error(`database-offline`)) 
-// { "level": "error", "msg": "Event saving", "errorMsg": "database-offline" }
+/*
+{
+  "level": "error", 
+  "message": "Event saving", 
+  "attributes": {
+    "error": "database-offline",
+    "stack" "<stack trace>"
+  }
+}
+*/
 
 log.warn(`Not too serious`, { userId: 1, name: 'John Doe'} )
-// { "level": "error", "msg": "Not too serious", "userId": 1, "name": "John Doe" }
+/*
+{
+  "level": "warn", 
+  "message": "Not too serious", 
+  "attributes": {
+    "userId": 1, 
+    "name": "John Doe" 
+  }
+}
+*/
 ```
 
 ## Methods
 - `log.debug()`
 - `log.info()`
-- `log.wanr()`
+- `log.warn()`
 - `log.error()`
 - `log.alert()`

--- a/index.js
+++ b/index.js
@@ -1,23 +1,23 @@
 module.exports = {
 
-  debug(message, meta) {
-    this.format(`debug`, message, meta).write()
+  debug(message, attributes) {
+    this.format(`debug`, message, attributes).write()
   },
 
-  info(message, meta) {
-    this.format(`info`, message, meta).write()
+  info(message, attributes) {
+    this.format(`info`, message, attributes).write()
   },
 
-  warn(message, meta) {
-    this.format(`warning`, message, meta).write()
+  warn(message, attributes) {
+    this.format(`warning`, message, attributes).write()
   },
 
-  error(message, meta) {
-    this.format(`error`, message, meta).write()
+  error(message, attributes) {
+    this.format(`error`, message, attributes).write()
   },
 
-  alert(message, meta) {
-    this.format(`alert`, message, meta).write()
+  alert(message, attributes) {
+    this.format(`alert`, message, attributes).write()
   },
 
   format(level, message, attributes) {

--- a/index.js
+++ b/index.js
@@ -13,29 +13,53 @@ module.exports = {
   },
 
   error(message, meta) {
-    this.format(`warning`, message, meta).write()
+    this.format(`error`, message, meta).write()
   },
 
   alert(message, meta) {
     this.format(`alert`, message, meta).write()
   },
 
-  format(level, msg, meta) {
-    if(typeof msg !== 'string') msg = JSON.stringify(msg)
+  format(level, message, attributes) {
 
-    if(meta instanceof Error) meta = { errorMsg: meta.message }
-    else if (typeof meta === 'string') meta = { meta }
+    try {
 
-    this.logLine = JSON.stringify({
-      level,
-      msg,
-      ...meta
-    })
+      if (attributes instanceof Error) {
+        attributes = {
+          error: attributes.message,
+          stack: attributes.stack
+        }
+      }
+      // remove empty object
+      else if (attributes && !Object.keys(attributes).length) {
+        attributes = undefined
+      }
+      // force attributes to be object
+      else if (typeof attributes === 'string') {
+        attributes = { string: attributes }
+      }
+
+      this.logLine = JSON.stringify({
+        level: String(level),
+        message: String(message),
+        attributes
+      })
+
+    } catch (err) {
+
+      // catch circular reference and other exception
+      attributes = { logError: err.message }
+      this.logLine = JSON.stringify({
+        level,
+        message,
+        attributes
+      })
+    }
 
     return this
   },
 
   write() {
-    console.log(this.logLine)
+    console.log('%s', this.logLine)
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rsc-nodejs-logger",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "RSC Node Logger",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "RSC Node Logger",
   "main": "index.js",
   "scripts": {
-    "test": "NODE_ENV=test mocha --recursive test"
+    "test": "NODE_ENV=test mocha --recursive test",
+    "coverage": "NODE_ENV=test nyc --all --reporter=html mocha --recursive test --timeout 5000 && open ./coverage/index.html"
   },
   "author": "Radio Systems Corporation",
   "license": "MIT",

--- a/test/index.js
+++ b/test/index.js
@@ -10,49 +10,93 @@ describe('rsc-clean-log-json', function () {
   })
 
   describe('format', function () {
-    it('should set logLine', function () {
+    it('should set level & message', function () {
       let output = JSON.stringify({
         level: 'test',
-        msg: 'my-message'
+        message: 'my-message'
       })
       let format = logger.format(`test`, `my-message`)
       assert.deepStrictEqual(format.logLine, output)
     })
 
-    it('should set error message in logLine', function () {
+    it('should set error message & stack when passed error object', function () {
+      let testError = new Error(`test-error-message`)
       let output = JSON.stringify({
         level: 'test',
-        msg: 'my-message',
-        errorMsg: 'my-error-message'
+        message: 'my-message',
+        attributes: {
+          error: testError.message,
+          stack: testError.stack
+        }
       })
-      let format = logger.format(`test`, `my-message`, new Error(`my-error-message`))
+      let format = logger.format(`test`, `my-message`, testError)
       assert.deepStrictEqual(format.logLine, output)
     })
 
-    it('should set logLine with meta string', function () {
+    it('should remove attributes object if empty object or array', function () {
       let output = JSON.stringify({
         level: 'test',
-        msg: 'my-message',
-        meta: 'my-meta-data'
+        message: 'my-message'
       })
-      let format = logger.format(`test`, `my-message`, `my-meta-data`)
+      let format = logger.format(`test`, `my-message`, {})
+      assert.deepStrictEqual(format.logLine, output)
+
+      format = logger.format(`test`, `my-message`, [])
       assert.deepStrictEqual(format.logLine, output)
     })
 
-    it('should set logLine with meta object', function () {
+    it('should set force attributes to object if string', function () {
       let output = JSON.stringify({
         level: 'test',
-        msg: 'my-message',
-        name: 'james-smith'
+        message: 'my-message',
+        attributes: { string: `my-string` }
       })
-      let format = logger.format(`test`, `my-message`, { name: `james-smith` })
+      let format = logger.format(`test`, `my-message`, `my-string`)
+      assert.deepStrictEqual(format.logLine, output)
+    })
+
+    it('should set logError for an exception', function () {
+      let circular = [];
+      circular[0] = circular;
+
+      let output = JSON.stringify({
+        level: 'test',
+        message: 'my-message',
+        attributes: {
+          logError: `Converting circular structure to JSON`
+        }
+      })
+      let format = logger.format(`test`, `my-message`, circular)
       assert.deepStrictEqual(format.logLine, output)
     })
   })
 
   describe('write', function () {
-    it.skip('should write to console.log', function() {
-      // need tests here
+    it('should write to console.log', function() {
+      logger.format(`test`, `my-message`, {})
+      logger.write()
+    })
+  })
+
+  describe('log levels', function () {
+    it('should write debug message', function() {
+      logger.debug(`my debug message`)
+    })
+
+    it('should write info message', function() {
+      logger.info(`my info message`)
+    })
+
+    it('should write warn message', function() {
+      logger.warn(`my warn message`)
+    })
+
+    it('should write error message', function() {
+      logger.error(`my error message`)
+    })
+
+    it('should write alert message', function() {
+      logger.alert(`my alert message`)
     })
   })
 


### PR DESCRIPTION
This is to start the conversation on implementing a new logging format. Choosing JSON in expectations of the AWS announcement this week on CloudWatch Logs.

This is a quick rough draft but hopefully will help get the idea across to start the conversation. Feel free to adjust and change until we get this to a good spot.

I'm choosing to not use a library to keep it simple. The popular logging libraries seem to do a lot - while we really just need a standard wrapper for `console.log()` - similar to our `clean-log` library.