### PR TITLE
Update build badges and version number for npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # RSC NodeJS JSON Logging Library
 
-[![Build Status](https://travis-ci.org/jveldboom/rsc-clean-log-json.svg?branch=master)](https://travis-ci.org/jveldboom/rsc-clean-log-json)
-[![Coverage Status](https://coveralls.io/repos/github/jveldboom/rsc-clean-log-json/badge.svg)](https://coveralls.io/github/jveldboom/rsc-clean-log-json)
+[![Build Status](https://travis-ci.org/RSC-IoT-Open-Source/rsc-clean-log-json.svg?branch=master)](https://travis-ci.org/RSC-IoT-Open-Source/rsc-clean-log-json)
+[![Coverage Status](https://coveralls.io/repos/github/RSC-IoT-Open-Source/rsc-clean-log-json/badge.svg?branch=master)](https://coveralls.io/github/RSC-IoT-Open-Source/rsc-clean-log-json?branch=master)
 
 Simple logging library to reduce initialization and config options.
 Basically just a wrapper around `console.log` in a standard JSON output format.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rsc-clean-log-json",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "RSC NodeJS JSON Logger",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Move the Travis CI & Coveralls builds from my personal account to the organization. I'm not 100% sure how the accounts work. I'm assuming anyone in the organization can login and make changes to it. Either way, it needed to be changed to be under the RSC-IoT-Open-Source org.

This change also updates the package version number to `0.1.2` to publish to npm once merged to master.